### PR TITLE
Bump mini_magick version

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'fastlane_core', '>= 0.25.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'fastimage', '~> 1.6.3' # fetch the image sizes
-  spec.add_dependency 'mini_magick', '~> 4.0.2' # to add badge image on app icon
+  spec.add_dependency 'mini_magick', '~> 4.5.1' # to add badge image on app icon
 
 end


### PR DESCRIPTION
Update the `mini_magick` dependency.  `badge` and `frameit` both depend on `mini_magick`, but in https://github.com/fastlane/fastlane/pull/4483 I bumped `frameit`'s mini_magick dependency which created gem conflicts for folks who use `fastlane` with both `badge` and `frameit`. 