### PR TITLE
tvOS icons support adding badge gravity

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-badge - add a badge to your iOS/Android app icon
+badge - add a badge to your tvOS/iOS/Android app icon
 ============
 
 [![Twitter: @DanielGri](https://img.shields.io/badge/contact-@DanielGri-blue.svg?style=flat)](https://twitter.com/DanielGri)
@@ -7,7 +7,7 @@ badge - add a badge to your iOS/Android app icon
 
 # Features
 
-This gem helps to add a badge to your iOS/Android app icon.
+This gem helps to add a badge to your tvOS/iOS/Android app icon.
 
 Yes that's it.
 It's built to easily integrate with [fastlane](https://github.com/fastlane/fastlane).
@@ -56,7 +56,7 @@ Call ```badge``` in your iOS projects root folder
     
 It will search all subfolders for your asset catalog app icon set and add the badge to the icons. 
 
-But you can also run badge on your Android icons.
+But you can also run badge on your Android or tvOS icons.
 You have to use the `--glob="/**/*.appiconset/*.{png,PNG}"` parameter to adjust where to find your icons.
 
 The keep the alpha channel in the icons use `--alpha_channel`

--- a/bin/badge
+++ b/bin/badge
@@ -32,6 +32,7 @@ class BadgeApplication
       c.option '--alpha_channel', 'Keeps/Adds an alpha channel to the icons'
       c.option '--custom STRING', String, 'Overlay a custom image on your icon'
       c.option '--no_badge', 'Removes the beta badge'
+      c.option '--badge_gravity STRING', String, 'Position of the badge on icon. Default: SouthEast - Choices include: NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast.'
       c.option '--shield STRING', String, 'Overlay a shield from shield.io on your icon, eg: Version-1.2-green'
       c.option '--shield_io_timeout INTEGER', Integer, 'The timeout in seconds we should wait the get a response from shield.io'
       c.option '--shield_gravity STRING', String, 'Position of shield on icon. Default: North - Choices include: NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast.'
@@ -43,6 +44,7 @@ class BadgeApplication
         params[:dark] = options.dark
         params[:custom] = options.custom
         params[:no_badge] = options.no_badge
+        params[:badge_gravity] = options.badge_gravity
         params[:shield] = options.shield
         params[:shield_gravity] = options.shield_gravity
         params[:shield_no_resize] = options.shield_no_resize

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -56,7 +56,7 @@ module Badge
           result = MiniMagick::Image.new(full_path)
           
           if !options[:no_badge]
-            result = add_badge(options[:custom], options[:dark], icon, options[:alpha], alpha_channel)
+            result = add_badge(options[:custom], options[:dark], icon, options[:alpha], alpha_channel, options[:badge_gravity])
             icon_changed = true
           end
           if shield
@@ -91,15 +91,7 @@ module Badge
         current_shield.resize "#{icon.width}x#{icon.height}>"
       end
       
-      result = result.composite(current_shield, 'png') do |c|
-        c.compose "Over"
-        c.alpha 'On' if alpha_channel
-        if shield_gravity
-          c.gravity shield_gravity
-        else
-          c.gravity "north"
-        end
-      end
+      result = composite(result, current_shield, alpha_channel, shield_gravity || "north")
     end
 
     def load_shield(shield_string)
@@ -116,7 +108,7 @@ module Badge
       end
     end
 
-    def add_badge(custom_badge, dark_badge, icon, alpha_badge, alpha_channel)
+    def add_badge(custom_badge, dark_badge, icon, alpha_badge, alpha_channel, badge_gravity)
       UI.message "'#{icon.path}'"
       UI.verbose "Adding badge image ontop of icon".blue
       if custom_badge && File.exist?(custom_badge) # check if custom image is provided
@@ -130,9 +122,14 @@ module Badge
       end
 
       badge.resize "#{icon.width}x#{icon.height}"
-      result = icon.composite(badge, 'png') do |c|
+      result = composite(icon, badge, alpha_channel, badge_gravity || "SouthEast")
+    end
+
+    def composite(image, overlay, alpha_channel, gravity)
+      image.composite(overlay, 'png') do |c|
         c.compose "Over"
         c.alpha 'On' unless !alpha_channel
+        c.gravity gravity
       end
     end
   end


### PR DESCRIPTION
Adding badges to non square icons, for example when using `badge` with tvOS icons, was generating a wrong result.

<img width="373" alt="tvos_fail" src="https://cloud.githubusercontent.com/assets/2320840/18601898/f71d84e2-7c65-11e6-920f-4446411e77ea.png">

The new option allow setting a gravity for the badge, as it was already possible for the shields. Using a default value of SouthEast which generates the right icon for Android, iOS and tvOS with the default badge image. It also allow more customisation to people overlaying custom images on their app icons.

<img width="373" alt="tvos_success" src="https://cloud.githubusercontent.com/assets/2320840/18601936/2b017c46-7c66-11e6-8ef6-1c4065f5276b.png">