### PR TITLE
Remove dependency to fastlane

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'fastlane_core', '>= 0.44.0', '< 1.0.0' # all shared code and dependencies
   spec.add_dependency 'fastimage', '~> 1.6' # fetch the image sizes
   spec.add_dependency 'mini_magick', '~> 4.5' # to add badge image on app icon
 


### PR DESCRIPTION
With an upcoming _fastlane_ release it is important to remove the dependency to _fastlane_ and _fastlane_core_, see https://github.com/fastlane/fastlane/issues/7412 for more information