### PR TITLE
[WIP] Working with svgs + new geometry options

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency 'curb', '~> 9.3'
   spec.add_dependency 'fastlane', '>= 2.0'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes
   spec.add_dependency 'mini_magick', '>= 4.5' # to add badge image on app icon

--- a/badge.gemspec
+++ b/badge.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'curb', '~> 9.3'
+  spec.add_dependency 'curb', '~> 0.9'
   spec.add_dependency 'fastlane', '>= 2.0'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes
   spec.add_dependency 'mini_magick', '>= 4.5' # to add badge image on app icon

--- a/lib/badge/options.rb
+++ b/lib/badge/options.rb
@@ -51,7 +51,6 @@ module Badge
 
         FastlaneCore::ConfigItem.new(key: :shield_scale,
                                      description: "Shield image scale factor; e.g, 0.5, 2, etc. - works with --shield_no_resize",
-                                     is_string: false,
                                      optional: true),
 
         FastlaneCore::ConfigItem.new(key: :shield_no_resize,

--- a/lib/badge/options.rb
+++ b/lib/badge/options.rb
@@ -41,8 +41,17 @@ module Badge
                                      type: Integer,
                                      optional: true),
 
+        FastlaneCore::ConfigItem.new(key: :shield_geometry,
+                                     description: "Position of shield on icon, relative to gravity e.g, +50+10%",
+                                     optional: true),
+
         FastlaneCore::ConfigItem.new(key: :shield_gravity,
                                      description: "Position of shield on icon. Default: North - Choices include: NorthWest, North, NorthEast, West, Center, East, South, West, South, SouthEast",
+                                     optional: true),
+
+        FastlaneCore::ConfigItem.new(key: :shield_scale,
+                                     description: "Shield image scale factor; e.g, 0.5, 2, etc. - works with --shield_no_resize",
+                                     is_string: false,
                                      optional: true),
 
         FastlaneCore::ConfigItem.new(key: :shield_no_resize,

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -1,6 +1,7 @@
 require 'fastimage'
 require 'timeout'
 require 'mini_magick'
+require 'curb'
 
 module Badge
   class Runner
@@ -61,7 +62,7 @@ module Badge
             icon_changed = true
           end
           if shield
-            result = add_shield(icon, result, shield, alpha_channel, options[:shield_gravity], options[:shield_no_resize])
+            result = add_shield(icon, result, shield, alpha_channel, options[:shield_gravity], options[:shield_no_resize], options[:shield_scale], options[:shield_geometry])
             icon_changed = true
           end
           
@@ -80,33 +81,32 @@ module Badge
       end
     end
 
-    def add_shield(icon, result, shield, alpha_channel, shield_gravity, shield_no_resize)
+    def add_shield(icon, result, shield, alpha_channel, shield_gravity, shield_no_resize, shield_scale, shield_geometry)
       UI.message "'#{icon.path}'"
       UI.verbose "Adding shield.io image ontop of icon".blue
 
       current_shield = MiniMagick::Image.open(shield.path)
-      
-      if icon.width > current_shield.width && !shield_no_resize
-        current_shield.resize "#{icon.width}x#{icon.height}<"
+      shield_scale ||= 1.0
+
+      if shield_no_resize
+        current_shield.density (90.5 * shield_scale.to_f).to_i
       else
-        current_shield.resize "#{icon.width}x#{icon.height}>"
+        current_shield.density (icon.width.to_f / current_shield.width * 90.5 * shield_scale.to_f).to_i
       end
-      
-      result = composite(result, current_shield, alpha_channel, shield_gravity || "north")
+
+      result = composite(result, current_shield, alpha_channel, shield_gravity || "north", shield_geometry)
     end
 
     def load_shield(shield_string)
-      url = Badge.shield_base_url + Badge.shield_path + shield_string + ".png"
-      file_name = shield_string + ".png"
+      url = Badge.shield_base_url + Badge.shield_path + shield_string + ".svg"
+      file_name = shield_string + ".svg"
 
       UI.verbose "Trying to load image from shield.io. Timeout: #{Badge.shield_io_timeout}s".blue
       UI.verbose "URL: #{url}".blue
 
-      shield = Tempfile.new(file_name).tap do |file|
-        file.binmode
-        file.write(open(url).read)
-        file.close
-      end
+      Curl::Easy.download(url, file_name)
+      
+      File.open(file_name)
     end
     
     def check_imagemagick!
@@ -143,11 +143,12 @@ module Badge
       result = composite(icon, badge, alpha_channel, badge_gravity || "SouthEast")
     end
 
-    def composite(image, overlay, alpha_channel, gravity)
+    def composite(image, overlay, alpha_channel, gravity, geometry = nil)
       image.composite(overlay, 'png') do |c|
         c.compose "Over"
         c.alpha 'On' unless !alpha_channel
         c.gravity gravity
+        c.geometry geometry if geometry
       end
     end
   end

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -85,16 +85,19 @@ module Badge
       UI.message "'#{icon.path}'"
       UI.verbose "Adding shield.io image ontop of icon".blue
 
-      current_shield = MiniMagick::Image.open(shield.path)
-      shield_scale ||= 1.0
+      svg_shield = MiniMagick::Image.open(shield.path)
+      new_path = "#{shield.path}.png"
+      shield_scale = shield_scale ? shield_scale.to_f : 1.0
 
       if shield_no_resize
-        current_shield.density (90.5 * shield_scale.to_f).to_i
+        `rsvg-convert #{shield.path} -z #{shield_scale} -o #{new_path}`
       else
-        current_shield.density (icon.width.to_f / current_shield.width * 90.5 * shield_scale.to_f).to_i
+        `rsvg-convert #{shield.path} -w #{(icon.width * shield_scale).to_i} -a -o #{new_path}`
       end
 
-      result = composite(result, current_shield, alpha_channel, shield_gravity || "north", shield_geometry)
+      png_shield = MiniMagick::Image.open(new_path)
+
+      result = composite(result, png_shield, alpha_channel, shield_gravity || "north", shield_geometry)
     end
 
     def load_shield(shield_string)


### PR DESCRIPTION
Hey Daniel, I wanted to open a PR for this *work in progress* change I have that manipulates SVGs in badge. This leads to better quality badges when resized and makes an especially big difference on Android.

Just wanted to start a conversation around this change.

Curb was added as a dependency due to a problem in my local environment, that keeps `net/http` from requesting from shield.io. I haven't figured out what this is yet. I'll see about at least separating this from the PR.

`rsvg-convert` is now a CLI dependency, as even when compiled with SVG support magick still has compatibility issues (inexplicable black badges on Travis for example). I need to add some error handling here.

I added new options, `shield_scale` and `shield_geometry` which allow you to resize the shield and move it around respectively.

*Example usage:* `bundle exec badge --glob "/../app/src/main/res/**/ic_launcher.png" --shield $SHIELD --no_badge --shield_geometry "+0+25%" --shield_scale 0.75`

Let me know what you think!