### PR TITLE
Raise error if custom badge image is not found

### DIFF
--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -17,6 +17,11 @@ module Badge
       UI.verbose "Verbose active... VERSION: #{Badge::VERSION}".blue
       UI.verbose "Parameters: #{options.values.inspect}".blue
 
+      if options[:custom] && !File.exist?(options[:custom])
+        UI.error("Could not find custom badge image")
+        UI.user_error!("Specify a valid custom badge image path!")
+      end
+
       alpha_channel = false
       if options[:alpha_channel]
         alpha_channel = true


### PR DESCRIPTION
Currently, if custom badge image path is passed and the image is not found, it uses default image.
This behavior makes users confused. I think it's better to have validation before running add_badge if custom path is passed.