### PR TITLE
Remove curb dependencies

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'curb', '~> 0.9'
   spec.add_dependency 'fastlane', '>= 2.0'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes
   spec.add_dependency 'mini_magick', '>= 4.5' # to add badge image on app icon


### PR DESCRIPTION
Currently, this plugin depends on curb.

But I think this dependency doesn't make sense.
We can use `open-uri` instead.

To install curb, we have to install libcurl. It's not installed on some environments.

I checked following situations:

- librsvg is enabled
- librsvg is disabled
- Request to shields.io is failed