### PR TITLE
Support custom shield.io parameters for generating shield

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ Sometimes the response from shields.io takes a long time and can timeout. You ca
 
 `--shield_gravity North` changes the postion of the shield on the icon. Choices include: NorthWest, North, NorthEast, West, Center, East, SouthWest, South, SouthEast.
 
+`--shield_parameters "colorA=abcdef&style=flat"` changes the parameters of the shield image. It uses a string of key-value pairs separated by ampersand as specified on shields.io, eg: colorA=abcdef&style=flat.
+
 In version [0.4.0](https://github.com/HazAT/badge/releases/tag/0.4.0) the default behavior of the shield graphic has been changed. The shield graphic will always be resized to **aspect fill** the icon instead of just adding the shield on the icon. The disable to new behaviour use `--shield_no_resize` which now only puts the shield on the icon again.
 
 Add ```--no_badge``` as an option to hide the beta badge completely if you just want to add a shield.

--- a/lib/badge/options.rb
+++ b/lib/badge/options.rb
@@ -40,6 +40,10 @@ module Badge
                                      description: "Overlay a shield from shields.io on your icon, eg: Version-1.2-green",
                                      optional: true),
 
+        FastlaneCore::ConfigItem.new(key: :shield_parameters,
+                                     description: "Parameters of the shield image. String of key-value pairs separated by ampersand as specified on shields.io, eg: colorA=abcdef&style=flat",
+                                     optional: true),
+
         FastlaneCore::ConfigItem.new(key: :shield_io_timeout,
                                      description: "The timeout in seconds we should wait the get a response from shields.io",
                                      type: Integer,

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -35,7 +35,7 @@ module Badge
           timeout = Badge.shield_io_timeout
           timeout = options[:shield_io_timeout] if options[:shield_io_timeout]
           Timeout.timeout(timeout.to_i) do
-            shield = load_shield(options[:shield]) if options[:shield]
+            shield = load_shield(options[:shield], options[:shield_parameters]) if options[:shield]
           end
         rescue Timeout::Error
           UI.error "Error loading image from shields.io timeout reached. Use --verbose for more info".red
@@ -127,8 +127,11 @@ module Badge
       result = composite(result, new_shield, alpha_channel, shield_gravity || "north", shield_geometry)
     end
 
-    def load_shield(shield_string)
+    def load_shield(shield_string, shield_parameters)
       url = Badge.shield_base_url + Badge.shield_path + shield_string + (@@rsvg_enabled ? ".svg" : ".png")
+      if shield_parameters
+        url = url + "?" + shield_parameters
+      end
       file_name = shield_string + (@@rsvg_enabled ? ".svg" : ".png")
 
       UI.verbose "Trying to load image from shields.io. Timeout: #{Badge.shield_io_timeout}s".blue


### PR DESCRIPTION
The badge plugin does not support custom parameters for generating shield icons (See issue #61).

Shield.io offers the option to customize the shield with parameters as described [here](http://shields.io/#styles).

This PR adds the option `--shield_parameters` which accepts a string of key-value pairs (separated by &) as defined on [shield.io](http://shields.io/#styles). Die parameters are appended to the shield.io url.