### PR TITLE
Error when downloading png from shields.io

### DIFF
--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -137,7 +137,10 @@ module Badge
       UI.verbose "Trying to load image from shields.io. Timeout: #{Badge.shield_io_timeout}s".blue
       UI.verbose "URL: #{url}".blue
 
-      Curl::Easy.download(url, file_name)
+      Curl::Easy.download(url, file_name) do |curl|
+        curl.follow_location = true
+      end
+
       MiniMagick::Image.open(file_name) unless @@rsvg_enabled
 
       File.open(file_name)


### PR DESCRIPTION
We use the badges gem in our Fastlane scripts via the [fastlane-plugin-badge](https://github.com/HazAT/fastlane-plugin-badge) repo however recently we started getting the following flag up in our CI:

<img width="703" alt="Screenshot 2019-07-10 at 11 49 34" src="https://user-images.githubusercontent.com/482871/60963472-cc0d4b80-a308-11e9-81cf-db113c2f99fa.png">

As a result, our app icons weren't being tagged correctly. After digging into the generated links, I realised that .png images have started being redirected on shields.io (badges/shields/pull/3644, badges/shields/issues/3663) so now the curl command in this library downloads a zero byte image.  

In this PR, I've solved the issue by adding the `follow_location` configuration that essentially is the `-L` parameter in `curl`

You can test this in your console by first running the following:

```sh
curl -I https://img.shields.io/badge/PR-1234-blue.png
```

You will then notice that you never get the response data, if you then add the redirect flag and run it again:

```sh
curl -IL https://img.shields.io/badge/PR-1234-blue.png
```

You'll be redirected successfully and be able to download the image 🎉 

I'm not sure if this is the best way to solve the problem so I've opened this PR as a kind of starting point, am happy to look at alternative solutions if possible so please let me know if we need to do so 👍 