### PR TITLE
Alternate shields URL

### DIFF
--- a/lib/badge/base.rb
+++ b/lib/badge/base.rb
@@ -28,7 +28,7 @@ module Badge
 	end
 
 	def self.shield_base_url
-		'https://img.shields.io'
+		'https://raster.shields.io'
 	end
 
 	def self.shield_path


### PR DESCRIPTION
We were getting timeout errors for the badge build step as the redirecting shields.io URL could not be resolved by the badge package.

The issue mentioned in https://github.com/HazAT/badge/issues/88 was not resolved for us in the latest master. By using the alternate https://raster.shields.io URL which does not use a redirect our builds have started working again though.

This PR replaces the URL.