### PR TITLE
Make 'fastlane' a development_dependency in badge.gemspec

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -21,8 +21,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'curb', '~> 0.9'
-  spec.add_dependency 'fastlane', '>= 2.0'
   spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # to add badge image on app icon
 
+  # Don't add a dependency to fastlane or fastlane_re
+  # since this would cause a circular dependency
+  spec.add_development_dependency 'fastlane', '>= 2.0'
 end


### PR DESCRIPTION
Resolved #97 

Thanks for all the prior work that has gone into this library, we've used it for a long time now and it's ace 🙏🙏🙏

As per my description in #97, this change marks the `fastlane` gem as a development dependency rather than a runtime dependency so this should break the cycle that people may be running into. 