### PR TITLE
Fix SVG conversion if file starts with -

### DIFF
--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -111,9 +111,9 @@ module Badge
         new_path = "#{shield.path}.png"
         begin
           if shield_no_resize
-            `rsvg-convert #{shield.path} -z #{shield_scale} -o #{new_path}`
+            `rsvg-convert -z #{shield_scale} -o #{new_path} -- #{shield.path}`
           else
-            `rsvg-convert #{shield.path} -w #{(icon.width * shield_scale).to_i} -a -o #{new_path}`
+            `rsvg-convert -w #{(icon.width * shield_scale).to_i} -a -o #{new_path} -- #{shield.path}`
           end
         rescue Exception => error
           UI.error "Other error occured. Use --verbose for more info".red


### PR DESCRIPTION
In case you wanted a shield that had only the message, without a label, the file starts with a hyphen ("-"). This hyphen needs to be escaped when running the rsvg-convert command for it to succeed.

Example shield - https://img.shields.io/badge/-beta-brightgreen