### PR TITLE
Remove unused gem fastimage

### DIFF
--- a/badge.gemspec
+++ b/badge.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'fastlane', '>= 2.0'
-  spec.add_dependency 'fastimage', '>= 1.6' # fetch the image sizes
   spec.add_dependency('mini_magick', '>= 4.9.4', '< 5.0.0') # to add badge image on app icon
 
 end

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -1,4 +1,3 @@
-require 'fastimage'
 require 'timeout'
 require 'mini_magick'
 require 'open-uri'


### PR DESCRIPTION
`fastimage` has been removed from dependencies since this commit (https://github.com/HazAT/badge/commit/a561f8b3160acfa9a37f32f322852cb761d396f0).

```
$ git bisect start master fb5963940610e54fd263f1295f2f87d965f789b4
Bisecting: 64 revisions left to test after this (roughly 6 steps)
[d7aa175c0a408a5e0ad29ed95eabfbb88ca50d52] Remove dependency to fastlane
$ git bisect run ag FastImage
running ag FastImage
Bisecting: 32 revisions left to test after this (roughly 5 steps)
[2d445bf8efe595f06d449507c173ecb11e64c830] Merge pull request #15 from achretien/handle-transparency
running ag FastImage
Bisecting: 15 revisions left to test after this (roughly 4 steps)
[b4bc87c1ee79a761649ec8d3704ceb3b75299c85] updated readme to reflect new action in fastlane
running ag FastImage
Bisecting: 7 revisions left to test after this (roughly 3 steps)
[77504f152538e7e336d77a82a38719f00b7758a1] added shield options and no_badge to hide the beta badge
running ag FastImage
Bisecting: 3 revisions left to test after this (roughly 2 steps)
[de6e4d90b01a48ee28555f8e8b3bd6d0815c528f] added jenkins PATH env fix
running ag FastImage
Bisecting: 1 revision left to test after this (roughly 1 step)
[a2d9eac4167709b53e773a1baecf2a5d3d04bbe8] added dark option, updated documentation
running ag FastImage
Bisecting: 0 revisions left to test after this (roughly 0 steps)
[a561f8b3160acfa9a37f32f322852cb761d396f0] added overlay to app icon, removed unused code, wrote documentation
running ag FastImage
a561f8b3160acfa9a37f32f322852cb761d396f0 is the first bad commit
commit a561f8b3160acfa9a37f32f322852cb761d396f0
Author: Daniel Griesser <daniel.griesser.86@gmail.com>
Date:   Wed Nov 4 21:35:56 2015 +0100

    added overlay to app icon, removed unused code, wrote documentation

 README.md                             |  63 ++++++++++++++++++++++++++++++--
 assets/beta_badge.png                 | Bin 0 -> 2741 bytes
 assets/icon175x175.png                | Bin 0 -> 16997 bytes
 assets/icon175x175_badged.png         | Bin 0 -> 11628 bytes
 assets/icon175x175_fitrack.png        | Bin 0 -> 10829 bytes
 assets/icon175x175_fitrack_badged.png | Bin 0 -> 8796 bytes
 badge.gemspec                         |   4 +--
 bin/badge                             |  11 +++---
 lib/badge.rb                          |   4 +--
 lib/badge/base.rb                     |  12 +++++++
 lib/badge/position.rb                 |   8 -----
 lib/badge/runner.rb                   |  66 +++++++++++++---------------------
 lib/badge/screenshot.rb               |  60 -------------------------------
 lib/badge/version.rb                  |   3 --
 14 files changed, 105 insertions(+), 126 deletions(-)
 create mode 100644 assets/beta_badge.png
 create mode 100644 assets/icon175x175.png
 create mode 100644 assets/icon175x175_badged.png
 create mode 100644 assets/icon175x175_fitrack.png
 create mode 100644 assets/icon175x175_fitrack_badged.png
 create mode 100644 lib/badge/base.rb
 delete mode 100644 lib/badge/position.rb
 delete mode 100644 lib/badge/screenshot.rb
 delete mode 100644 lib/badge/version.rb
bisect run success
```