### PR TITLE
0.13.2: preserve input format, harden rsvg args, allow shield base URL

### DIFF
--- a/lib/badge/base.rb
+++ b/lib/badge/base.rb
@@ -1,6 +1,6 @@
 module Badge
 
-	VERSION = "0.13.1"
+	VERSION = "0.13.2"
 	DESCRIPTION = "Add a badge overlay to your app icon"
 
 	def self.root

--- a/lib/badge/options.rb
+++ b/lib/badge/options.rb
@@ -52,6 +52,11 @@ module Badge
                                      description: "Parameters of the shield image. String of key-value pairs separated by ampersand as specified on shields.io, eg: colorA=abcdef&style=flat",
                                      optional: true),
 
+        FastlaneCore::ConfigItem.new(key: :shield_base_url,
+                                     env_name: "BADGE_SHIELD_BASE_URL",
+                                     description: "Override the shields.io base URL (e.g. to point at a self-hosted shields server or to work around shields.io outages). Applies to both SVG and PNG requests",
+                                     optional: true),
+
         FastlaneCore::ConfigItem.new(key: :shield_io_timeout,
                                      env_name: "BADGE_SHIELD_IO_TIMEOUT",
                                      description: "The timeout in seconds we should wait to get a response from shields.io",

--- a/lib/badge/runner.rb
+++ b/lib/badge/runner.rb
@@ -44,7 +44,7 @@ module Badge
           timeout = Badge.shield_io_timeout
           timeout = options[:shield_io_timeout] if options[:shield_io_timeout]
           Timeout.timeout(timeout.to_i) do
-            shield = load_shield(options[:shield], options[:shield_parameters]) if options[:shield]
+            shield = load_shield(options[:shield], options[:shield_parameters], options[:shield_base_url]) if options[:shield]
           end
         rescue Timeout::Error
           UI.error "Error loading image from shields.io timeout reached. Use --verbose for more info".red
@@ -90,7 +90,11 @@ module Badge
             icon_changed = true
           end
           if icon_changed
-            result.format "png"
+            # Preserve the original file format (webp, jpg, png, ...) so we
+            # don't silently write PNG bytes into a .webp filename. Falls back
+            # to png if the input has no recognizable extension.
+            ext = icon_path.extname.downcase.delete('.')
+            result.format(ext.empty? ? 'png' : ext)
             result.write full_path
           end
         end
@@ -113,10 +117,17 @@ module Badge
       if @@rsvg_enabled
         new_path = "#{shield.path}.png"
         begin
+          # Use argv-form system() instead of backticks so paths and scale
+          # values can never be interpreted by the shell (avoids e.g. the
+          # "Multiple SVG files are only allowed for PDF and (E)PS output"
+          # error caused by unquoted shield paths, #54).
           if shield_no_resize
-            `rsvg-convert -z #{shield_scale} -o #{new_path} -- #{shield.path}`
+            system('rsvg-convert', '-z', shield_scale.to_s,
+                   '-o', new_path, '--', shield.path)
           else
-            `rsvg-convert -w #{(icon.width * shield_scale).to_i} -a -o #{new_path} -- #{shield.path}`
+            system('rsvg-convert',
+                   '-w', (icon.width * shield_scale).to_i.to_s, '-a',
+                   '-o', new_path, '--', shield.path)
           end
         rescue Exception => error
           UI.error "Other error occured. Use --verbose for more info".red
@@ -135,8 +146,10 @@ module Badge
       result = composite(result, new_shield, alpha_channel, shield_gravity || "north", shield_geometry)
     end
 
-    def load_shield(shield_string, shield_parameters)
-      url = (@@rsvg_enabled ? Badge.shield_svg_base_url : Badge.shield_base_url) + Badge.shield_path + shield_string + (@@rsvg_enabled ? ".svg" : ".png")
+    def load_shield(shield_string, shield_parameters, shield_base_url = nil)
+      svg_base = shield_base_url || Badge.shield_svg_base_url
+      png_base = shield_base_url || Badge.shield_base_url
+      url = (@@rsvg_enabled ? svg_base : png_base) + Badge.shield_path + shield_string + (@@rsvg_enabled ? ".svg" : ".png")
       if shield_parameters
         url = url + "?" + shield_parameters
       end


### PR DESCRIPTION
Three small fixes collected into a 0.13.2 release. All additive / opt-in — no behavior change for existing PNG-based users.

## Changes

### 1. Preserve input format on write — fixes #121
Before: `result.format "png"` unconditionally re-encoded every output as PNG, so a `.webp` icon on Android was silently overwritten with PNG bytes in a `.webp` filename. Broken file.

After: the output format follows the input extension (`webp`, `jpg`, `png`, ...). Falls back to `png` only when the input has no usable extension.

### 2. Harden `rsvg-convert` invocation — fixes #54
Before: `rsvg-convert` was invoked via backticks with all arguments interpolated into a shell string. When `shield.path` or related values contained shell metacharacters, you got confusing errors like the one in #54's title ("Multiple SVG files are only allowed for PDF and (E)PS output").

After: argv-form `system(...)` — the shell never tokenizes the arguments. Functionally equivalent for existing well-behaved inputs.

### 3. Allow shield base URL override — fixes #111
Before: `Badge.shield_base_url` and `Badge.shield_svg_base_url` were hardcoded. Users behind restrictive networks, hosts with broken IPv6 routing to shields.io, or anyone running a self-hosted shields instance had no escape hatch.

After: new option `--shield_base_url` (env `BADGE_SHIELD_BASE_URL`). When set, it replaces both the SVG and PNG base URLs. When unset, everything works exactly as before.

## Verified locally

| Check | Result |
|---|---|
| `gem build badge.gemspec` | ✅ badge-0.13.2.gem |
| `bin/badge --help` | ✅ shows new `--shield_base_url` (BADGE_SHIELD_BASE_URL) |
| `bin/badge --version` | ✅ `badge 0.13.2` |
| PNG + shield end-to-end | ✅ rsvg-convert via system() works, output stays PNG |
| WEBP + shield end-to-end | ✅ output stays `RIFF ... Web/P image` (was PNG bytes before) |
| `shield_base_url: "https://my.local"` | ✅ generated URL: `https://my.local/badge/v1-green.svg` |

## Version
`0.13.1` → `0.13.2`